### PR TITLE
Fix BaseProfiler throwing a CME

### DIFF
--- a/AtlasParent/Atlas/src/main/java/cc/funkemunky/api/profiling/BaseProfiler.java
+++ b/AtlasParent/Atlas/src/main/java/cc/funkemunky/api/profiling/BaseProfiler.java
@@ -121,12 +121,6 @@ public class BaseProfiler implements Profiler {
     }
 
     private Timing getTiming(String name) {
-        return timingsMap.computeIfAbsent(name, key -> {
-           Timing timing = new Timing(key);
-
-           timingsMap.put(key, timing);
-
-           return timing;
-        });
+        return timingsMap.computeIfAbsent(name, Timing::new);
     }
 }


### PR DESCRIPTION
Map#computeIfAbsent was used incorrectly, resulting in a ConcurrentModificationException being thrown in later java versions.