### PR TITLE
Fix Interval size being larger than max.

### DIFF
--- a/AtlasParent/Atlas/src/main/java/cc/funkemunky/api/utils/objects/Interval.java
+++ b/AtlasParent/Atlas/src/main/java/cc/funkemunky/api/utils/objects/Interval.java
@@ -52,7 +52,7 @@ public class Interval extends LinkedList<Double> {
     }
 
     public boolean add(double x) {
-        if (size() > max) {
+        if (size() == max) {
             removeLast();
         }
         addFirst(x);


### PR DESCRIPTION
Currently an Interval will have an actual maximum of greater than the maximum specified. For example, if 20 is specified the actual maximum will be 21.